### PR TITLE
feat(theme): patriotic refinements — brighter reds, cyan→blue cleanup…

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,12 +1,15 @@
 <svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <radialGradient id="g" cx="50%" cy="45%" r="70%">
-      <stop offset="0%" stop-color="#0f172a" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#111827" stop-opacity="0.0"/>
-    </radialGradient>
-  </defs>
   <rect width="512" height="512" fill="none"/>
-  <circle cx="256" cy="256" r="170" fill="none" stroke="#22d3ee" stroke-width="28" stroke-linecap="round"/>
-  <circle cx="392" cy="190" r="22" fill="#22d3ee"/>
-  <circle cx="256" cy="256" r="120" fill="url(#g)"/>
+  
+  <!-- Base Blue Cross -->
+  <rect x="106" y="206" width="300" height="100" rx="25" fill="#1e3a8a"/>
+  <rect x="206" y="106" width="100" height="300" rx="25" fill="#1e3a8a"/>
+  
+  <!-- Middle White Cross -->
+  <rect x="146" y="221" width="220" height="70" rx="20" fill="#ffffff"/>
+  <rect x="221" y="146" width="70" height="220" rx="20" fill="#ffffff"/>
+  
+  <!-- Inner Red Cross -->
+  <rect x="176" y="236" width="160" height="40" rx="15" fill="#ef4444"/>
+  <rect x="236" y="176" width="40" height="160" rx="15" fill="#ef4444"/>
 </svg>

--- a/src/components/Bot360Logo.jsx
+++ b/src/components/Bot360Logo.jsx
@@ -55,45 +55,24 @@ const Bot360Logo = ({
         className="relative mr-2 flex-shrink-0"
         style={{ height: sizeValues.iconSize, width: sizeValues.iconSize }}
       >
-        <svg 
-          xmlns="http://www.w3.org/2000/svg" 
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 100 100"
-          height={sizeValues.iconSize} 
+          height={sizeValues.iconSize}
           width={sizeValues.iconSize}
-          fill="none"
-          stroke={colors[variant].orbital}
-          strokeWidth="4"
           className="transition-colors duration-300"
         >
-          {/* Outer Circle */}
-          <circle cx="50" cy="50" r="45" />
-          
-          {/* Orbital Rings */}
-          <ellipse 
-            cx="50" 
-            cy="50" 
-            rx="35" 
-            ry="20" 
-            transform="rotate(30 50 50)" 
-            strokeDasharray="4 2"
-          />
-          <ellipse 
-            cx="50" 
-            cy="50" 
-            rx="30" 
-            ry="40" 
-            transform="rotate(-20 50 50)" 
-            strokeDasharray="4 2"
-          />
-          
-          {/* Center Dot */}
-          <circle 
-            cx="50" 
-            cy="50" 
-            r="6" 
-            fill={colors[variant].ai} 
-            stroke="none"
-          />
+          {/* Base Cross – Blue */}
+          <rect x="37" y="15" width="26" height="70" rx="8" fill="#1e3a8a" />
+          <rect x="15" y="37" width="70" height="26" rx="8" fill="#1e3a8a" />
+
+          {/* Middle Cross – White */}
+          <rect x="41" y="21" width="18" height="58" rx="6" fill="#ffffff" />
+          <rect x="21" y="41" width="58" height="18" rx="6" fill="#ffffff" />
+
+          {/* Inner Cross – Red */}
+          <rect x="45" y="27" width="10" height="46" rx="4" fill="#ef4444" />
+          <rect x="27" y="45" width="46" height="10" rx="4" fill="#ef4444" />
         </svg>
       </div>
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -106,7 +106,7 @@ const Footer = () => {
                 />
                 <button 
                   type="submit" 
-                  className="w-full sm:w-auto bg-red-600 hover:bg-red-500 text-white px-3 py-2 rounded-lg sm:rounded-r-lg sm:rounded-l-none text-sm font-medium transition-colors"
+                  className="w-full sm:w-auto bg-red-500 hover:bg-red-400 text-white px-3 py-2 rounded-lg sm:rounded-r-lg sm:rounded-l-none text-sm font-medium transition-colors"
                 >
                   Subscribe
                 </button>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -456,7 +456,7 @@ const Header = () => {
       </div>
 
       {/* Patriotic stripe */}
-      <div className="h-0.5 w-full bg-gradient-to-r from-red-600 via-white to-blue-600"></div>
+      <div className="h-0.5 w-full bg-gradient-to-r from-red-500 via-white to-blue-600"></div>
     </header>
   );
 };

--- a/src/components/chat/ChatInterfaceWithConversations.js
+++ b/src/components/chat/ChatInterfaceWithConversations.js
@@ -479,7 +479,7 @@ const ChatInterfaceWithConversations = () => {
                                         className: `flex items-center gap-1 px-3 py-2 rounded-lg ${
                                             isFavorite 
                                                 ? 'bg-cyan-400 text-indigo-900' 
-                                                : 'bg-[rgba(34,211,238,.2)] border border-cyan-400 text-cyan-400'
+                                                : 'bg-[rgba(59,130,246,.2)] border border-cyan-400 text-cyan-400'
                                         } font-semibold transition-all hover:bg-cyan-400 hover:text-indigo-900`,
                                         title: isFavorite ? "Remove from favorites" : "Add to favorites",
                                         children: [
@@ -505,7 +505,7 @@ const ChatInterfaceWithConversations = () => {
                                 _jsxs("button", { 
                                     id: "insightsToggle", 
                                     onClick: () => setShowInsightsPanel(!showInsightsPanel),
-                                    className: `insights-toggle-button flex items-center gap-1 px-3 py-2 rounded-lg ${showInsightsPanel ? 'bg-cyan-400 text-indigo-900' : 'bg-[rgba(34,211,238,.2)] border border-cyan-400 text-cyan-400'} font-semibold transition-all hover:bg-cyan-400 hover:text-indigo-900`,
+                                    className: `insights-toggle-button flex items-center gap-1 px-3 py-2 rounded-lg ${showInsightsPanel ? 'bg-cyan-400 text-indigo-900' : 'bg-[rgba(59,130,246,.2)] border border-cyan-400 text-cyan-400'} font-semibold transition-all hover:bg-cyan-400 hover:text-indigo-900`,
                                     children: [
                                         _jsx("svg", { 
                                             xmlns: "http://www.w3.org/2000/svg", 
@@ -529,7 +529,7 @@ const ChatInterfaceWithConversations = () => {
                                         className: `insights-toggle-button flex items-center gap-1 px-3 py-2 rounded-lg ${
                                             isShared
                                                 ? 'bg-cyan-400 text-indigo-900' 
-                                                : 'bg-[rgba(34,211,238,.2)] border border-cyan-400 text-cyan-400'
+                                                : 'bg-[rgba(59,130,246,.2)] border border-cyan-400 text-cyan-400'
                                         } font-semibold transition-all hover:bg-cyan-400 hover:text-indigo-900`,
                                         children: [
                                             _jsx("svg", { 
@@ -550,7 +550,7 @@ const ChatInterfaceWithConversations = () => {
                                 isAuthenticated && !activeConversation && messages.length > 0 && (
                                     _jsxs("button", {
                                         onClick: () => setShowSaveModal(true),
-                                        className: "flex items-center gap-1 px-3 py-2 rounded-lg bg-[rgba(34,211,238,.2)] border border-cyan-400 text-cyan-400 font-semibold transition-all hover:bg-cyan-400 hover:text-indigo-900",
+                                        className: "flex items-center gap-1 px-3 py-2 rounded-lg bg-[rgba(59,130,246,.2)] border border-cyan-400 text-cyan-400 font-semibold transition-all hover:bg-cyan-400 hover:text-indigo-900",
                                         children: [
                                             _jsx("svg", {
                                                 xmlns: "http://www.w3.org/2000/svg",

--- a/src/components/chat/SimpleChatWithHistory.js
+++ b/src/components/chat/SimpleChatWithHistory.js
@@ -476,14 +476,14 @@ const SimpleChatWithHistory = () => {
                                                     isAuthenticated && (
                                                         _jsx("button", { 
                                                             onClick: goToConversations, 
-                                                            className: "text-sm px-3 py-1 rounded bg-[rgba(34,211,238,.15)] border border-cyan-400 hover:bg-cyan-400 hover:text-gray-900 transition",
+                                                            className: "text-sm px-3 py-1 rounded bg-[rgba(59,130,246,.15)] border border-cyan-400 hover:bg-cyan-400 hover:text-gray-900 transition",
                                                             children: "My Conversations" 
                                                         })
                                                     ),
                                                     _jsx("button", { 
                                                         onClick: resetChat, 
                                                         id: "backBtn", 
-                                                        className: "text-sm px-3 py-1 rounded bg-[rgba(34,211,238,.15)] border border-cyan-400 hover:bg-cyan-400 hover:text-gray-900 transition",
+                                                        className: "text-sm px-3 py-1 rounded bg-[rgba(59,130,246,.15)] border border-cyan-400 hover:bg-cyan-400 hover:text-gray-900 transition",
                                                         children: "Back to Assistants" 
                                                     })
                                                 ] 
@@ -549,7 +549,7 @@ const SimpleChatWithHistory = () => {
                                                     isAuthenticated && !isChatSaved && messages.length > 0 && (
                                                         _jsxs("button", {
                                                             onClick: handleSaveConversation,
-                                                            className: "flex items-center gap-1 px-3 py-2 rounded-lg bg-[rgba(34,211,238,.2)] border border-cyan-400 text-cyan-300 font-semibold transition-all hover:bg-cyan-400 hover:text-gray-900",
+                                                            className: "flex items-center gap-1 px-3 py-2 rounded-lg bg-[rgba(59,130,246,.2)] border border-cyan-400 text-cyan-300 font-semibold transition-all hover:bg-cyan-400 hover:text-gray-900",
                                                             children: [
                                                                 _jsx("svg", {
                                                                     xmlns: "http://www.w3.org/2000/svg",
@@ -569,7 +569,7 @@ const SimpleChatWithHistory = () => {
                                                     _jsxs("button", { 
                                                         id: "insightsToggle", 
                                                         onClick: () => setShowInsightsPanel(!showInsightsPanel),
-                                                        className: `insights-toggle-button flex items-center gap-1 px-3 py-2 rounded-lg ${showInsightsPanel ? 'bg-cyan-400 text-gray-900' : 'bg-[rgba(34,211,238,.2)] border border-cyan-400 text-cyan-300'} font-semibold transition-all hover:bg-cyan-400 hover:text-gray-900`,
+                                                        className: `insights-toggle-button flex items-center gap-1 px-3 py-2 rounded-lg ${showInsightsPanel ? 'bg-cyan-400 text-gray-900' : 'bg-[rgba(59,130,246,.2)] border border-cyan-400 text-cyan-300'} font-semibold transition-all hover:bg-cyan-400 hover:text-gray-900`,
                                                         children: [
                                                             _jsx("svg", { 
                                                                 xmlns: "http://www.w3.org/2000/svg", 
@@ -589,7 +589,7 @@ const SimpleChatWithHistory = () => {
                                                     // Simple share button (no persistence)
                                                     _jsxs("button", { 
                                                         id: "shareBtn", 
-                                                        className: "insights-toggle-button flex items-center gap-1 px-3 py-2 rounded-lg bg-[rgba(34,211,238,.2)] border border-cyan-400 text-cyan-300 font-semibold transition-all hover:bg-cyan-400 hover:text-gray-900",
+                                                        className: "insights-toggle-button flex items-center gap-1 px-3 py-2 rounded-lg bg-[rgba(59,130,246,.2)] border border-cyan-400 text-cyan-300 font-semibold transition-all hover:bg-cyan-400 hover:text-gray-900",
                                                         onClick: () => {
                                                             if (navigator.share) {
                                                                 navigator.share({

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -79,7 +79,7 @@ const HomePage: React.FC = () => {
             ? window.open(pricingUrl, '_blank', 'noopener,noreferrer')
             : navigate(pricingUrl)
         }
-        className="fixed top-4 right-4 z-50 inline-flex justify-center items-center px-6 py-2 border-2 border-white text-sm font-medium rounded-full shadow-sm text-white bg-red-600 hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-300 whitespace-nowrap transition-colors animate-pulse"
+        className="fixed top-4 right-4 z-50 inline-flex justify-center items-center px-6 py-2 border-2 border-white text-sm font-medium rounded-full shadow-sm text-white bg-red-500 hover:bg-red-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-300 whitespace-nowrap transition-colors animate-pulse"
       >
         Unlock All Assistants – Upgrade to Premium
       </button>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 /** @type {import('tailwindcss').Config} */
+const colors = require('tailwindcss/colors');
 module.exports = {
   content: [
     "./index.html",
@@ -8,20 +9,20 @@ module.exports = {
     extend: {
       colors: {
         /* -----------------------------------------------------------------
-           Brand palette: primary (cyan) & secondary (indigo)
+           Brand palette: primary (bright red) & secondary (indigo)
         -----------------------------------------------------------------*/
         primary: {
-          50:  '#ecfeff',
-          100: '#cffafe',
-          200: '#a5f3fc',
-          300: '#67e8f9',
-          400: '#22d3ee', // brand primary
-          500: '#06b6d4',
-          600: '#0891b2',
-          700: '#0e7490',
-          800: '#155e75',
-          900: '#164e63',
-          950: '#083344',
+          50:  '#fef2f2',
+          100: '#fee2e2',
+          200: '#fecaca',
+          300: '#fca5a5',
+          400: '#f87171',
+          500: '#ef4444', // brand primary (brighter red)
+          600: '#dc2626',
+          700: '#b91c1c',
+          800: '#991b1b',
+          900: '#7f1d1d',
+          950: '#450a0a',
         },
         secondary: {
           50:  '#eef2ff',
@@ -43,6 +44,12 @@ module.exports = {
           nodeActive: '#4338ca', // secondary-700
           nodePulse: '#a5b4fc',  // secondary-300
         },
+
+        /* -----------------------------------------------------------------
+           Globally remap all Tailwind `cyan-*` utility classes to blue so
+           existing class names immediately adopt the patriotic palette.
+        -----------------------------------------------------------------*/
+        cyan: colors.blue,
       },
       animation: {
         'typing': 'typing 1.2s steps(3) infinite',


### PR DESCRIPTION
…, cross logo & favicon\n\n- Brighten reds (red-600→red-500; hovers to red-400) in Header/Footer/Home\n- Replace orbital logo with red/white/blue cross; update favicon to match\n- Replace inline cyan RGBA with blue in chat UIs\n- Tailwind: remap cyan palette to blue; set red as primary brand\n\nDroid-assisted: validation passed (build), lint has known repo errors