### PR TITLE
feat(brand): gold cross logo in header (horizontal bar moved up); imp…

### DIFF
--- a/src/components/Bot360Logo.jsx
+++ b/src/components/Bot360Logo.jsx
@@ -62,14 +62,11 @@ const Bot360Logo = ({
           width={sizeValues.iconSize}
           className="transition-colors duration-300"
         >
-          {/* Christian flag */}
-          {/* White field */}
-          <rect x="8" y="18" width="84" height="54" rx="6" fill="#ffffff" />
-          {/* Blue canton */}
-          <rect x="8" y="18" width="40" height="32" rx="4" fill="#1e3a8a" />
-          {/* Red Latin cross inside canton */}
-          <rect x="24" y="22" width="8" height="24" rx="2" fill="#ff4d4d" />
-          <rect x="16" y="30" width="24" height="8" rx="2" fill="#ff4d4d" />
+          {/* Gold cross icon */}
+          {/* Vertical bar */}
+          <rect x="45" y="20" width="10" height="60" rx="3" fill="#d4af37" />
+          {/* Horizontal bar (moved above center) */}
+          <rect x="30" y="35" width="40" height="10" rx="3" fill="#d4af37" />
         </svg>
       </div>
 

--- a/src/components/CharacterSelection.tsx
+++ b/src/components/CharacterSelection.tsx
@@ -447,7 +447,7 @@ const CharacterSelection: React.FC = () => {
       {renderAlphaNav()}
       
       <div className="max-w-7xl mx-auto bg-white/8 backdrop-blur-sm rounded-2xl p-6 border border-white/15 shadow-xl">
-        <h1 className="text-4xl md:text-5xl font-extrabold text-center text-[#0f172a] mb-8 tracking-tight drop-shadow-lg">
+        <h1 className="text-4xl md:text-5xl font-extrabold text-center text-white mb-8 tracking-tight drop-shadow-lg">
           Choose Your Leader
         </h1>
         

--- a/src/components/ScalableCharacterSelection.jsx
+++ b/src/components/ScalableCharacterSelection.jsx
@@ -818,7 +818,7 @@ const ScalableCharacterSelection = () => {
                         /* Title ----------------------------------------------------- */
                         /* Main Heading ------------------------------------------------ */
                         _jsx("h1", {
-                            className: "text-4xl md:text-5xl font-extrabold text-center text-[#0f172a] mb-8 tracking-tight drop-shadow-lg",
+                            className: "text-4xl md:text-5xl font-extrabold text-center text-white mb-8 tracking-tight drop-shadow-lg",
                             style: { fontFamily: 'inherit' },
                             children: "Choose Your Leader"
                         }),

--- a/src/components/ScalableCharacterSelection.tsx
+++ b/src/components/ScalableCharacterSelection.tsx
@@ -508,7 +508,7 @@ const ScalableCharacterSelection: React.FC = () => {
       {renderAlphaNav()}
       
       <div className="max-w-7xl mx-auto bg-white/8 backdrop-blur-sm rounded-2xl p-6 border border-white/15 shadow-xl">
-        <h1 className="text-4xl md:text-5xl font-extrabold text-center text-[#0f172a] mb-8 tracking-tight drop-shadow-lg">
+        <h1 className="text-4xl md:text-5xl font-extrabold text-center text-white mb-8 tracking-tight drop-shadow-lg">
           Choose Your Leader
         </h1>
         


### PR DESCRIPTION
…rove home selection heading contrast\n\n- Replace flag icon with gold cross (#d4af37) in Bot360Logo\n- Move cross horizontal bar above center for better proportions\n- Make 'Choose Your Leader' heading text white for legibility\n\nDroid-assisted: build passed