### PR TITLE
Fix Supabase RLS: profiles recursion; enable admin/superadmin CRUD on characters (Droid-assisted)

### DIFF
--- a/docs/rls-fixes-2025-09-22.md
+++ b/docs/rls-fixes-2025-09-22.md
@@ -1,0 +1,28 @@
+# Supabase RLS Fixes — Profiles recursion + Characters CRUD (2025-09-22)
+
+Summary of changes implemented via `sql/2025-09-22-rls-fixes.sql`:
+
+- Removed recursive `profiles` policies that selected from `profiles` inside their own USING/WITH CHECK clauses (this caused “infinite recursion detected”).
+- Replaced with safe policies using SECURITY DEFINER helpers:
+  - `public.current_user_role()` and `public.current_user_owner_slug()`.
+  - Select policies: self, admin within org, superadmin (all).
+  - Update policies: self (cannot change role/owner), admin within org (cannot set superadmin), superadmin (all).
+  - Delete policy: superadmin only.
+- Added `characters` policies to allow INSERT/UPDATE/DELETE for `admin` and `superadmin` while keeping public SELECT.
+
+Verification steps (in Supabase SQL editor):
+
+1) Run the migration SQL file contents.
+2) Sign in with a non-admin account and ensure:
+   - `select * from profiles where id = auth.uid()` works (no recursion error).
+   - `insert into characters(...)` is blocked (not admin).
+3) Sign in with admin:
+   - `select * from profiles` returns only same-org rows.
+   - `insert/update/delete` on `characters` succeeds.
+4) Sign in with superadmin:
+   - Full access to `profiles` and `characters` as defined above.
+
+Notes:
+
+- If the helper functions from the prior migration are missing, re-run section 7 of `sql/ask-charlie-bot360ai-migrations.sql` to create them, then apply this fix.
+- The app’s Admin pages depend on these policies for CSV import and character edits to succeed.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "generate:downloads": "node scripts/generateDownloads.mjs",
-    "generate:logo-pack": "node scripts/generateLogoPack.mjs"
+    "generate:logo-pack": "node scripts/generateLogoPack.mjs",
+    "db:apply-rls-fixes": "node scripts/apply-rls-fixes.mjs sql/2025-09-22-rls-fixes.sql",
+    "db:promote-superadmin": "node scripts/promote-user.mjs stroka2@verizon.net"
   },
   "dependencies": {
     "@stripe/stripe-js": "^7.4.0",
@@ -40,6 +42,7 @@
     "globals": "^16.0.0",
     "jszip": "^3.10.1",
     "pdfkit": "^0.17.2",
+    "pg": "^8.16.3",
     "postcss": "^8.5.6",
     "pptxgenjs": "^4.0.1",
     "puppeteer": "^24.19.0",

--- a/scripts/apply-rls-fixes.mjs
+++ b/scripts/apply-rls-fixes.mjs
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+import pg from 'pg';
+
+const { Client } = pg;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Load .env.local explicitly (do not commit this file)
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+
+async function main() {
+  const sqlFile = process.argv[2] || 'sql/2025-09-22-rls-fixes.sql';
+  const sqlPath = path.resolve(process.cwd(), sqlFile);
+
+  if (!process.env.SUPABASE_DB_URL) {
+    console.error('Missing SUPABASE_DB_URL in .env.local');
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(sqlPath)) {
+    console.error(`SQL file not found: ${sqlPath}`);
+    process.exit(1);
+  }
+
+  const sql = fs.readFileSync(sqlPath, 'utf8');
+
+  const client = new Client({
+    connectionString: process.env.SUPABASE_DB_URL,
+    ssl: { rejectUnauthorized: false }
+  });
+
+  try {
+    await client.connect();
+    console.log(`Applying SQL from ${sqlPath} ...`);
+    await client.query(sql);
+    console.log('SQL applied successfully.');
+  } catch (err) {
+    console.error('Error applying SQL:', err?.message || err);
+    if (err?.position) {
+      console.error('Position:', err.position);
+    }
+    process.exit(2);
+  } finally {
+    await client.end();
+  }
+}
+
+main();

--- a/scripts/promote-user.mjs
+++ b/scripts/promote-user.mjs
@@ -1,0 +1,44 @@
+import dotenv from 'dotenv';
+import path from 'path';
+import pg from 'pg';
+
+const { Client } = pg;
+
+dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+
+async function main() {
+  const emailArg = process.argv[2];
+  if (!emailArg) {
+    console.error('Usage: node scripts/promote-user.mjs <email>');
+    process.exit(1);
+  }
+  if (!process.env.SUPABASE_DB_URL) {
+    console.error('Missing SUPABASE_DB_URL in .env.local');
+    process.exit(1);
+  }
+
+  const client = new Client({
+    connectionString: process.env.SUPABASE_DB_URL,
+    ssl: { rejectUnauthorized: false }
+  });
+
+  try {
+    await client.connect();
+    const { rowCount } = await client.query(
+      `UPDATE public.profiles SET role = 'superadmin' WHERE lower(email) = lower($1)`,
+      [emailArg]
+    );
+    if (rowCount === 0) {
+      console.error('No matching profile found.');
+      process.exit(2);
+    }
+    console.log(`Promoted ${emailArg} to superadmin.`);
+  } catch (err) {
+    console.error('Error promoting user:', err?.message || err);
+    process.exit(3);
+  } finally {
+    await client.end();
+  }
+}
+
+main();

--- a/sql/2025-09-22-rls-fixes.sql
+++ b/sql/2025-09-22-rls-fixes.sql
@@ -1,0 +1,152 @@
+-- =================================================================
+-- Supabase RLS Fixes (Profiles recursion + Characters CRUD)
+-- Date: 2025-09-22
+-- Notes:
+-- - Replaces recursive profiles policies that referenced the profiles table
+--   inside profiles policies (causing "infinite recursion detected" errors).
+-- - Adds admin/superadmin CRUD policies for characters.
+-- - Uses helper functions current_user_role() and current_user_owner_slug()
+--   which are SECURITY DEFINER and safe to call in policies.
+-- =================================================================
+
+-- Ensure helper functions exist (defined in prior migrations). If not, fail loudly.
+-- You can re-run the previous migration section 7 to create them if missing.
+
+-- =============================
+-- 1) PROFILES: Drop old policies
+-- =============================
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+-- Drop legacy recursive policies if present (ignore errors if absent)
+DO $$ BEGIN
+  BEGIN EXECUTE 'DROP POLICY "Users can view own profile" ON public.profiles'; EXCEPTION WHEN others THEN END;
+  BEGIN EXECUTE 'DROP POLICY "Users can update own profile" ON public.profiles'; EXCEPTION WHEN others THEN END;
+  BEGIN EXECUTE 'DROP POLICY "Admins can view all profiles" ON public.profiles'; EXCEPTION WHEN others THEN END;
+  BEGIN EXECUTE 'DROP POLICY "Admins can update all profiles" ON public.profiles'; EXCEPTION WHEN others THEN END;
+  BEGIN EXECUTE 'DROP POLICY "Pastors can view regular user profiles" ON public.profiles'; EXCEPTION WHEN others THEN END;
+  BEGIN EXECUTE 'DROP POLICY "Pastors can update regular user profiles" ON public.profiles'; EXCEPTION WHEN others THEN END;
+  -- Drop any prior iterations of the newer policies to avoid duplicates
+  BEGIN EXECUTE 'DROP POLICY IF EXISTS profiles_select_self ON public.profiles'; EXCEPTION WHEN others THEN END;
+  BEGIN EXECUTE 'DROP POLICY IF EXISTS profiles_select_superadmin ON public.profiles'; EXCEPTION WHEN others THEN END;
+  BEGIN EXECUTE 'DROP POLICY IF EXISTS profiles_select_admin_org ON public.profiles'; EXCEPTION WHEN others THEN END;
+  BEGIN EXECUTE 'DROP POLICY IF EXISTS profiles_update_self ON public.profiles'; EXCEPTION WHEN others THEN END;
+  BEGIN EXECUTE 'DROP POLICY IF EXISTS profiles_update_admin ON public.profiles'; EXCEPTION WHEN others THEN END;
+  BEGIN EXECUTE 'DROP POLICY IF EXISTS profiles_update_superadmin ON public.profiles'; EXCEPTION WHEN others THEN END;
+  BEGIN EXECUTE 'DROP POLICY IF EXISTS profiles_delete_superadmin ON public.profiles'; EXCEPTION WHEN others THEN END;
+END $$;
+
+-- =============================
+-- 2) PROFILES: Safe policies
+-- =============================
+
+-- SELECT: self
+CREATE POLICY profiles_select_self
+ON public.profiles
+FOR SELECT
+TO authenticated
+USING (id = auth.uid());
+
+-- SELECT: superadmin can view all
+CREATE POLICY profiles_select_superadmin
+ON public.profiles
+FOR SELECT
+TO authenticated
+USING (public.current_user_role() = 'superadmin');
+
+-- SELECT: admin can view only within their org (owner_slug)
+CREATE POLICY profiles_select_admin_org
+ON public.profiles
+FOR SELECT
+TO authenticated
+USING (
+  public.current_user_role() = 'admin'
+  AND owner_slug IS NOT DISTINCT FROM public.current_user_owner_slug()
+);
+
+-- UPDATE: self may update own profile but cannot change role/owner_slug
+CREATE POLICY profiles_update_self
+ON public.profiles
+FOR UPDATE
+TO authenticated
+USING (id = auth.uid())
+WITH CHECK (
+  id = auth.uid()
+  AND role = public.current_user_role()
+  AND owner_slug IS NOT DISTINCT FROM public.current_user_owner_slug()
+);
+
+-- UPDATE: admin may update profiles within their org (but cannot set superadmin)
+CREATE POLICY profiles_update_admin
+ON public.profiles
+FOR UPDATE
+TO authenticated
+USING (
+  public.current_user_role() = 'admin'
+  AND owner_slug IS NOT DISTINCT FROM public.current_user_owner_slug()
+)
+WITH CHECK (
+  public.current_user_role() = 'admin'
+  AND owner_slug IS NOT DISTINCT FROM public.current_user_owner_slug()
+  AND COALESCE(role::text, 'user') <> 'superadmin'
+);
+
+-- UPDATE: superadmin may update any profile
+CREATE POLICY profiles_update_superadmin
+ON public.profiles
+FOR UPDATE
+TO authenticated
+USING (public.current_user_role() = 'superadmin')
+WITH CHECK (public.current_user_role() = 'superadmin');
+
+-- DELETE: superadmin only (optional hard-guard)
+CREATE POLICY profiles_delete_superadmin
+ON public.profiles
+FOR DELETE
+TO authenticated
+USING (public.current_user_role() = 'superadmin');
+
+-- Note: INSERT on profiles is typically performed by trigger handle_new_user()
+-- with SECURITY DEFINER – no explicit INSERT policy needed for clients.
+
+-- ======================================
+-- 3) CHARACTERS: Admin/superadmin CRUD
+-- ======================================
+
+ALTER TABLE public.characters ENABLE ROW LEVEL SECURITY;
+
+-- Keep public read (already present in prior migrations). Re-create idempotently.
+DO $$ BEGIN
+  BEGIN EXECUTE 'DROP POLICY IF EXISTS "Characters are viewable by all users" ON public.characters'; EXCEPTION WHEN others THEN END;
+END $$;
+CREATE POLICY "Characters are viewable by all users" ON public.characters
+  FOR SELECT USING (true);
+
+-- Admins and superadmins can insert/update/delete
+DO $$ BEGIN
+  BEGIN EXECUTE 'DROP POLICY IF EXISTS characters_insert_admins ON public.characters'; EXCEPTION WHEN others THEN END;
+  BEGIN EXECUTE 'DROP POLICY IF EXISTS characters_update_admins ON public.characters'; EXCEPTION WHEN others THEN END;
+  BEGIN EXECUTE 'DROP POLICY IF EXISTS characters_delete_admins ON public.characters'; EXCEPTION WHEN others THEN END;
+END $$;
+
+CREATE POLICY characters_insert_admins
+ON public.characters
+FOR INSERT
+TO authenticated
+WITH CHECK (public.current_user_role() IN ('admin','superadmin'));
+
+CREATE POLICY characters_update_admins
+ON public.characters
+FOR UPDATE
+TO authenticated
+USING (public.current_user_role() IN ('admin','superadmin'))
+WITH CHECK (public.current_user_role() IN ('admin','superadmin'));
+
+CREATE POLICY characters_delete_admins
+ON public.characters
+FOR DELETE
+TO authenticated
+USING (public.current_user_role() IN ('admin','superadmin'));
+
+-- =================================================================
+-- End of migration
+-- =================================================================


### PR DESCRIPTION
Summary
- RLS fixes applied in Supabase: profiles recursion resolved; admin/superadmin CRUD enabled on characters.
- Docs included: docs/rls-fixes-2025-09-22.md.

Validation
- npm ci (frozen) ✔️
- npm run build ✔️
- Live DB verification (after applying SQL in Studio):
  * profiles: self-select works; no recursion errors
  * role for stroka2@verizon.net: superadmin
  * characters: insert/update/delete succeed for superadmin; blocked for basic users (by policy)

Deployment Notes
- SQL already run in Studio; no further infra steps required.

